### PR TITLE
Move volver button and show admin labels

### DIFF
--- a/admin/admin-lista.php
+++ b/admin/admin-lista.php
@@ -96,21 +96,26 @@ $intenciones = $wpdb->get_results("SELECT * FROM $table_name ORDER BY activa DES
                         <?php if ($intencion->page_id): ?>
                             <a href="<?php echo get_permalink($intencion->page_id); ?>" class="button button-small" target="_blank" title="<?php echo $i18n->get('backend', 'btn_ver_pagina', 'Ver Página'); ?>">
                                 <span class="dashicons dashicons-external"></span>
+                                <?php echo $i18n->get('backend', 'btn_ver_pagina', 'Ver Página'); ?>
                             </a>
                         <?php endif; ?>
-                        
+
                         <a href="<?php echo admin_url('admin.php?page=rezo-comunitario-agregar&editar=' . $intencion->id); ?>" class="button button-small" title="<?php echo $i18n->get('backend', 'btn_editar', 'Editar'); ?>">
                             <span class="dashicons dashicons-edit"></span>
+                            <?php echo $i18n->get('backend', 'btn_editar', 'Editar'); ?>
                         </a>
                         
                         <form method="post" style="display: inline;">
                             <?php wp_nonce_field('rezo_admin'); ?>
                             <input type="hidden" name="action" value="pausar">
                             <input type="hidden" name="id" value="<?php echo $intencion->id; ?>">
-                            <button type="submit" class="button button-small" title="<?php echo $intencion->activa ? 
-                                $i18n->get('backend', 'btn_pausar', 'Pausar') : 
+                            <button type="submit" class="button button-small" title="<?php echo $intencion->activa ?
+                                $i18n->get('backend', 'btn_pausar', 'Pausar') :
                                 $i18n->get('backend', 'btn_activar', 'Activar'); ?>">
                                 <span class="dashicons dashicons-<?php echo $intencion->activa ? 'pause' : 'controls-play'; ?>"></span>
+                                <?php echo $intencion->activa ?
+                                    $i18n->get('backend', 'btn_pausar', 'Pausar') :
+                                    $i18n->get('backend', 'btn_activar', 'Activar'); ?>
                             </button>
                         </form>
                         
@@ -118,10 +123,11 @@ $intenciones = $wpdb->get_results("SELECT * FROM $table_name ORDER BY activa DES
                             <?php wp_nonce_field('rezo_admin'); ?>
                             <input type="hidden" name="action" value="eliminar">
                             <input type="hidden" name="id" value="<?php echo $intencion->id; ?>">
-                            <button type="submit" class="button button-small button-link-delete" 
+                            <button type="submit" class="button button-small button-link-delete"
                                     onclick="return confirm('<?php echo $i18n->get('backend', 'confirmar_eliminar', '¿Estás seguro? Esta acción eliminará también la página asociada y no se puede deshacer.'); ?>')"
                                     title="<?php echo $i18n->get('backend', 'btn_eliminar', 'Eliminar'); ?>">
                                 <span class="dashicons dashicons-trash"></span>
+                                <?php echo $i18n->get('backend', 'btn_eliminar', 'Eliminar'); ?>
                             </button>
                         </form>
                     </div>

--- a/assets/rezo.css
+++ b/assets/rezo.css
@@ -98,6 +98,9 @@
   color: #007cba;
   text-decoration: none;
   font-weight: 500;
+  display: block;
+  margin: 20px auto 0;
+  text-align: center;
 }
 
 .intencion-content {
@@ -205,6 +208,8 @@
   max-height: 90vh;
   overflow-y: auto;
   position: relative;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .close {

--- a/templates/intencion-detalle.php
+++ b/templates/intencion-detalle.php
@@ -1,11 +1,6 @@
 <?php $porcentaje = ($intencion->avemarias_actuales / $intencion->objetivo_avemarias) * 100; ?>
 
 <div class="rezo-intencion-detalle" data-intencion-id="<?php echo $intencion->id; ?>">
-    <div class="intencion-header">
-        <h1><?php echo esc_html($intencion->titulo); ?></h1>
-        <a href="javascript:history.back()" class="btn-volver"><?php echo $i18n->get('frontend', 'btn_volver', '← Volver'); ?></a>
-    </div>
-    
     <div class="intencion-content">
         <div class="descripcion-section">
             <?php echo wp_kses_post($intencion->descripcion); ?>
@@ -30,6 +25,9 @@
                 <?php echo $i18n->get('frontend', 'btn_agregar_rezos', '🙏 Agregar mis Rezos'); ?>
             </button>
         </div>
+        <a href="javascript:history.back()" class="btn-volver">
+            <?php echo $i18n->get('frontend', 'btn_volver', '← Volver'); ?>
+        </a>
     </div>
     
     <!-- Modal del formulario -->


### PR DESCRIPTION
## Summary
- hide the intention title
- move **Volver** button below the content
- center the popup horizontally
- show text next to admin action icons

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684713d3b3e08333ad9c102d8caa8693