### PR TITLE
Normalize rosary progress text and re-center overlay

### DIFF
--- a/assets/rezo.css
+++ b/assets/rezo.css
@@ -131,6 +131,11 @@
   margin: 20px 0;
 }
 
+.progress-circle svg {
+  display: block;
+  margin: 0 auto;
+}
+
 .progress-ring {
   transform: rotate(-90deg);
 }
@@ -139,25 +144,61 @@
   transform: none;
 }
 
-.progress-ring-progress {
-  transition: stroke-dashoffset 0.5s ease-in-out;
+.progress-ring-circle {
+  stroke: url(#rosaryCordGradient);
+  opacity: 0.85;
+  fill: transparent;
+}
+
+.rosary-tail {
+  fill: none;
+  stroke: url(#rosaryCordGradient);
+  stroke-width: 6;
   stroke-linecap: round;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
+}
+
+.progress-ring-progress {
+  transition: stroke-dashoffset 0.6s ease-in-out;
+  stroke: url(#rosaryProgressGradient);
+  stroke-linecap: round;
+  fill: transparent;
+  filter: drop-shadow(0 0 8px rgba(32, 197, 216, 0.45));
+  transform: rotate(-90deg);
+  transform-box: fill-box;
+  transform-origin: center;
 }
 
 .rosary-bead {
-  fill: #e6e6e6;
-  transition: fill 0.3s ease-in-out;
+  fill: url(#rosaryBeadGradient);
+  transition: transform 0.3s ease, filter 0.3s ease;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
 }
 
 .rosary-bead.filled {
-  fill: #17a2b8;
+  fill: url(#rosaryBeadFilledGradient);
+  filter: url(#beadShadow);
+}
+
+.rosary-bead.just-filled {
+  animation: beadPop 0.6s ease forwards;
+}
+
+.rosary-bead.next-target {
+  filter: drop-shadow(0 0 10px rgba(32, 197, 216, 0.65));
+  animation: beadPulse 1.8s ease-in-out infinite;
 }
 
 .progress-text {
   position: absolute;
-  top: 50%;
+  top: calc(100% * 100 / 240);
   left: 50%;
   transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
   text-align: center;
 }
 
@@ -173,6 +214,52 @@
   font-size: 0.9rem;
   color: #6c757d;
   margin-top: 4px;
+}
+
+.progress-circle.completed .porcentaje {
+  color: #0f6674;
+  text-shadow: 0 0 12px rgba(23, 162, 184, 0.35);
+}
+
+.progress-circle.completed .progress-ring-progress {
+  filter: drop-shadow(0 0 14px rgba(23, 162, 184, 0.55));
+}
+
+@keyframes beadPop {
+  0% {
+    transform: scale(0.8);
+  }
+  60% {
+    transform: scale(1.15);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes beadPulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-ring-progress {
+    transition: none;
+  }
+
+  .rosary-bead {
+    transition: none;
+  }
+
+  .rosary-bead.just-filled,
+  .rosary-bead.next-target {
+    animation: none;
+  }
 }
 
 .acciones-section {

--- a/assets/rezo.js
+++ b/assets/rezo.js
@@ -126,45 +126,55 @@ window.rezoFunctions = {
     if (typeof window.jQuery === "undefined") return
 
     const $ = window.jQuery
-    const avemariasElement = $(".avemarias")
-    const porcentajeElement = $(".porcentaje")
+    const progressContainers = $(".progress-circle")
 
-    if (avemariasElement.length && porcentajeElement.length) {
-      const textoActual = avemariasElement.text()
-      const objetivo = textoActual.split(" / ")[1]
-      avemariasElement.text(avemariasActuales.toLocaleString() + " / " + objetivo)
-      porcentajeElement.text(porcentaje.toFixed(1) + "%")
+    progressContainers.each(function () {
+      const container = $(this)
+      const objetivo = Number.parseInt(container.data("avemariasObjetivo"), 10)
+      const avemariasElement = container.find(".avemarias")
 
-      const path = $(".progress-ring-progress")
-      if (path.length) {
-        let length = 0
-        const el = path[0]
-        if (el.tagName.toLowerCase() === "circle") {
-          const radius = parseFloat(el.getAttribute("r"))
-          length = 2 * Math.PI * radius
-        } else if (el.getTotalLength) {
-          length = el.getTotalLength()
+      container.data("avemariasActuales", avemariasActuales)
+      container.attr("data-avemarias-actuales", avemariasActuales)
+
+      if (avemariasElement.length) {
+        if (!Number.isNaN(objetivo) && objetivo > 0) {
+          avemariasElement.text(
+            `${avemariasActuales.toLocaleString()} / ${objetivo.toLocaleString()}`,
+          )
+        } else {
+          avemariasElement.text(avemariasActuales.toLocaleString())
         }
-        const offset = length - (porcentaje / 100) * length
-        path.css("stroke-dashoffset", offset)
       }
+    })
 
-      if ($(".rosary-bead").length) {
-        window.rezoFunctions.updateBeads(porcentaje)
-      }
-    }
+    window.rezoFunctions.refreshProgressMeta(porcentaje)
   },
 
   updateBeads: (porcentaje) => {
     if (typeof window.jQuery === "undefined") return
 
     const $ = window.jQuery
+    const boundedPercentage = Math.min(100, Math.max(0, porcentaje))
+    const nextTargetIndex = boundedPercentage >= 100 ? -1 : Math.floor(boundedPercentage / 10)
+
     $(".rosary-bead").each(function (index) {
       const threshold = (index + 1) * 10
-      if (porcentaje >= threshold) {
-        $(this).addClass("filled")
-      } else {
-        $(this).removeClass("filled")
+      const shouldFill = boundedPercentage >= threshold
+      const wasFilled = $(this).hasClass("filled")
+
+      $(this).toggleClass("filled", shouldFill)
+      $(this).removeClass("next-target")
+
+      if (!wasFilled && shouldFill) {
+        const bead = $(this)
+        bead.addClass("just-filled")
+        setTimeout(() => {
+          bead.removeClass("just-filled")
+        }, 700)
+      }
+
+      if (!shouldFill && index === nextTargetIndex) {
+        $(this).addClass("next-target")
       }
     })
   },
@@ -194,12 +204,107 @@ window.rezoFunctions = {
     path.css("stroke-dashoffset", length)
 
     setTimeout(() => {
-      const offset = length - (porcentaje / 100) * length
+      const boundedPercentage = Math.min(100, Math.max(0, porcentaje))
+      const offset = length - (boundedPercentage / 100) * length
       path.css("stroke-dashoffset", offset)
-      if ($(".rosary-bead").length) {
-        window.rezoFunctions.updateBeads(porcentaje)
-      }
+      window.rezoFunctions.refreshProgressMeta(boundedPercentage)
     }, 500)
+  },
+
+  refreshProgressMeta: (porcentaje) => {
+    if (typeof window.jQuery === "undefined") return
+
+    const $ = window.jQuery
+    const boundedPercentage = Math.min(100, Math.max(0, porcentaje))
+    const progressContainers = $(".progress-circle")
+
+    progressContainers.each(function () {
+      const container = $(this)
+      const porcentajeElement = container.find(".porcentaje")
+      const path = container.find(".progress-ring-progress")
+      const progressText = container.find(".progress-text")
+      const objetivo = Number.parseInt(container.data("avemariasObjetivo"), 10)
+      const avemariasElement = container.find(".avemarias")
+      const avemariasActuales = Number.parseInt(container.data("avemariasActuales"), 10) || 0
+
+      if (progressText.length) {
+        progressText
+          .children()
+          .not(".porcentaje, .avemarias")
+          .remove()
+
+        if (typeof Node !== "undefined") {
+          progressText
+            .contents()
+            .filter(function () {
+              return this.nodeType === Node.TEXT_NODE && this.textContent.trim() !== ""
+            })
+            .remove()
+        }
+      }
+
+      if (avemariasElement.length) {
+        if (!Number.isNaN(objetivo) && objetivo > 0) {
+          avemariasElement.text(
+            `${avemariasActuales.toLocaleString()} / ${objetivo.toLocaleString()}`,
+          )
+        } else {
+          avemariasElement.text(avemariasActuales.toLocaleString())
+        }
+      }
+
+      container.attr("data-porcentaje", boundedPercentage)
+      container.data("porcentaje", boundedPercentage)
+
+      if (path.length) {
+        let length = 0
+        const el = path[0]
+        if (el.tagName.toLowerCase() === "circle") {
+          const radius = parseFloat(el.getAttribute("r"))
+          length = 2 * Math.PI * radius
+        } else if (el.getTotalLength) {
+          length = el.getTotalLength()
+        }
+        const offset = length - (boundedPercentage / 100) * length
+        path.css("stroke-dashoffset", offset)
+      }
+
+      if (porcentajeElement.length) {
+        if (!porcentajeElement.data("defaultText")) {
+          porcentajeElement.data("defaultText", porcentajeElement.text())
+        }
+
+        const completeText = porcentajeElement.data("complete-text") || "¡Rosario completado!"
+        const timeoutId = container.data("completeTimeoutId")
+
+        if (boundedPercentage >= 100) {
+          container.addClass("completed")
+          if (!container.data("completeDisplayed")) {
+            container.data("completeDisplayed", true)
+            porcentajeElement.text(completeText)
+            const newTimeoutId = window.setTimeout(() => {
+              porcentajeElement.text("100%")
+              container.removeData("completeTimeoutId")
+            }, 4000)
+            container.data("completeTimeoutId", newTimeoutId)
+          } else {
+            porcentajeElement.text("100%")
+          }
+        } else {
+          container.removeClass("completed")
+          if (timeoutId) {
+            window.clearTimeout(timeoutId)
+            container.removeData("completeTimeoutId")
+          }
+          container.data("completeDisplayed", false)
+          porcentajeElement.text(`${boundedPercentage.toFixed(1)}%`)
+        }
+      }
+    })
+
+    if ($(".rosary-bead").length) {
+      window.rezoFunctions.updateBeads(boundedPercentage)
+    }
   },
 }
 

--- a/templates/intencion-detalle.php
+++ b/templates/intencion-detalle.php
@@ -6,8 +6,10 @@ for ($i = 0; $i < 10; $i++) {
     $angle = deg2rad(-90 + $i * 36);
     $x = 100 + 88 * cos($angle);
     $y = 100 + 88 * sin($angle);
-    $beadsMarkup .= '<circle class="rosary-bead" cx="' . $x . '" cy="' . $y . '" r="' . $beadRadius . '"></circle>';
+    $beadsMarkup .= '<circle class="rosary-bead" data-bead-index="' . $i . '" cx="' . $x . '" cy="' . $y . '" r="' . $beadRadius . '" role="presentation"></circle>';
 }
+
+$porcentaje = min(100, $porcentaje);
 ?>
 
 <div class="rezo-intencion-detalle" data-intencion-id="<?php echo $intencion->id; ?>">
@@ -18,16 +20,43 @@ for ($i = 0; $i < 10; $i++) {
         
         <div class="progreso-section">
             <h3><?php echo $i18n->get('frontend', 'progreso_rezos', 'Progreso de Rezos'); ?></h3>
-            <div class="progress-circle" data-porcentaje="<?php echo min(100, $porcentaje); ?>">
-                <svg class="progress-ring rosary" width="200" height="240" viewBox="0 0 200 240">
-                    <path class="progress-ring-circle" stroke="#e6e6e6" stroke-width="8" fill="transparent" d="M100 12 A88 88 0 1 1 100 188 A88 88 0 1 1 100 12 M100 188 L100 218 M90 218 L110 218 M100 218 L100 238" />
-                    <path class="progress-ring-progress" stroke="#17a2b8" stroke-width="8" fill="transparent" d="M100 12 A88 88 0 1 1 100 188 A88 88 0 1 1 100 12 M100 188 L100 218 M90 218 L110 218 M100 218 L100 238" />
-
+            <div
+                class="progress-circle<?php echo $porcentaje >= 100 ? ' completed' : ''; ?>"
+                data-porcentaje="<?php echo $porcentaje; ?>"
+                data-avemarias-actuales="<?php echo (int) $intencion->avemarias_actuales; ?>"
+                data-avemarias-objetivo="<?php echo (int) $intencion->objetivo_avemarias; ?>"
+            >
+                <svg class="progress-ring rosary" width="200" height="240" viewBox="0 0 200 240" aria-hidden="true">
+                    <defs>
+                        <linearGradient id="rosaryCordGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                            <stop offset="0%" stop-color="#d9d9d9" />
+                            <stop offset="100%" stop-color="#b3b3b3" />
+                        </linearGradient>
+                        <linearGradient id="rosaryProgressGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                            <stop offset="0%" stop-color="#20c5d8" />
+                            <stop offset="100%" stop-color="#138496" />
+                        </linearGradient>
+                        <radialGradient id="rosaryBeadGradient" cx="50%" cy="35%" r="65%">
+                            <stop offset="0%" stop-color="#fdfdfd" />
+                            <stop offset="55%" stop-color="#e6e6e6" />
+                            <stop offset="100%" stop-color="#cfcfcf" />
+                        </radialGradient>
+                        <radialGradient id="rosaryBeadFilledGradient" cx="50%" cy="35%" r="65%">
+                            <stop offset="0%" stop-color="#7ef5ff" />
+                            <stop offset="55%" stop-color="#17a2b8" />
+                            <stop offset="100%" stop-color="#0f6674" />
+                        </radialGradient>
+                        <filter id="beadShadow" x="-50%" y="-50%" width="200%" height="200%">
+                            <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="rgba(0, 0, 0, 0.25)" />
+                        </filter>
+                    </defs>
+                    <circle class="progress-ring-circle" cx="100" cy="100" r="88" stroke-width="8" fill="transparent" />
+                    <path class="rosary-tail" d="M100 188 L100 218 M90 218 L110 218 M100 218 L100 238" />
+                    <circle class="progress-ring-progress" cx="100" cy="100" r="88" stroke-width="8" fill="transparent" />
                     <?php echo $beadsMarkup; ?>
-
                 </svg>
-                <div class="progress-text">
-                    <span class="porcentaje"><?php echo number_format($porcentaje, 1); ?>%</span>
+                <div class="progress-text" aria-live="polite">
+                    <span class="porcentaje" data-complete-text="<?php echo esc_attr($i18n->get('frontend', 'progreso_completo', '¡Rosario completado!')); ?>"><?php echo number_format($porcentaje, 1); ?>%</span>
                     <span class="avemarias"><?php echo number_format($intencion->avemarias_actuales); ?> / <?php echo number_format($intencion->objetivo_avemarias); ?></span>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- store the rosary progress counts in data attributes so JavaScript updates can rebuild the Ave Marías string without leftover artifacts
- clean stray DOM nodes from the progress text and keep the percentage/count overlay centered on the rosary ring
- adjust the rosary CSS to vertically align the overlay and ensure the SVG stays centered in its container

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6904b7a4c1748333929cb994030e78ef